### PR TITLE
Fix correpondences of frames and poses in ICL traj0

### DIFF
--- a/gradslam/datasets/icl.py
+++ b/gradslam/datasets/icl.py
@@ -312,7 +312,7 @@ class ICL(data.Dataset):
                     warnings.warn(msg.format(end, len(lines), trajectory_name))
                 # traj0 is missing a pose in livingRoom0n.gt.sim, thus we remove one of the frames
                 if trajectory_name == "living_room_traj0_frei_png":
-                    lines = lines[:-1]
+                    lines = lines[1:]
                 lines = lines[start:end]
 
             if self.load_poses:


### PR DESCRIPTION
### Description
ICL traj0 of living room scene contains 1 extra frame without pose that breaks correpondences between frames and poses (https://github.com/anastasiia-kornilova/gradslam/blob/607428e65879f889c373ec18635e8946ea3a262b/gradslam/datasets/icl.py#L313). To fix this, gradslam loader originally drops the last frame. Considering registration of point clouds from frames with corresponding poses using this assumption, I've found out that they are wrong, because they give a bit distorted aggregated point cloud. If I build a map from registered point clouds dropping the first frame, then it gives coherent map, that means that it is better assumption for GT correspondences. This PR fixes those correspondences between frames and poses.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/gradslam/gradslam/blob/main/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before?
- [x] **Pass all tests**: did you test in local ? `pytest tests/`
- [ ] Unittests: did you add tests for your new functionality?
- [ ] Documentations: did you build documentation ? `cd docs/ && sphinx-build . _build`
- [ ] Implementation: is your code well commented and follow conventions ? `black gradslam/ && flake8 gradslam/`
- [ ] Docstrings & Typing: has your code documentation and typing ?
- [ ] Update notebooks & documentation if necessary

### gradslam Team
<details>
  <summary>gradslam team workflow</summary>
  
  - [ ] Triage
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `gradslam` design conventions?
  - [ ] Is the documentation complete enough?
  - [ ] Are the tests covering simple and corner cases?
 
</details>
